### PR TITLE
fix: Adding in lifecycle rules to ignore supported_environment tags

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -421,6 +421,12 @@ resource "aws_subnet" "public" {
     var.tags,
     var.public_subnet_tags,
   )
+  lifecycle {
+  ignore_changes = [
+    tags["Supported_Environment"]
+  ]
+}
+
 }
 
 #####################
@@ -451,6 +457,11 @@ resource "aws_subnet" "public_eks_blue" {
     var.tags,
     var.public_eks_subnet_tags_blue,
   )
+  lifecycle {
+  ignore_changes = [
+    tags["Supported_Environment"]
+  ]
+}
 }
 
 resource "aws_subnet" "public_eks_green" {
@@ -476,6 +487,11 @@ resource "aws_subnet" "public_eks_green" {
     var.tags,
     var.public_eks_subnet_tags_green,
   )
+  lifecycle {
+  ignore_changes = [
+    tags["Supported_Environment"]
+  ]
+}
 }
 
 #################
@@ -503,6 +519,12 @@ resource "aws_subnet" "private" {
     var.tags,
     var.private_subnet_tags,
   )
+  lifecycle {
+  ignore_changes = [
+    tags["Supported_Environment"]
+  ]
+}
+
 }
 
 #################
@@ -530,6 +552,12 @@ resource "aws_subnet" "ftp" {
     var.tags,
     var.ftp_subnet_tags,
   )
+  lifecycle {
+  ignore_changes = [
+    tags["Supported_Environment"]
+  ]
+}
+
 }
 
 ##################
@@ -559,6 +587,11 @@ resource "aws_subnet" "private_eks_blue" {
     var.tags,
     var.private_eks_subnet_tags_blue,
   )
+  lifecycle {
+  ignore_changes = [
+    tags["Supported_Environment"]
+  ]
+}
 }
 
 resource "aws_subnet" "private_eks_green" {
@@ -583,6 +616,11 @@ resource "aws_subnet" "private_eks_green" {
     var.tags,
     var.private_eks_subnet_tags_green,
   )
+  lifecycle {
+  ignore_changes = [
+    tags["Supported_Environment"]
+  ]
+}
 }
 
 ################################################################################
@@ -610,6 +648,12 @@ resource "aws_subnet" "database" {
     var.tags,
     var.database_subnet_tags,
   )
+  lifecycle {
+  ignore_changes = [
+    tags["Supported_Environment"]
+  ]
+}
+
 }
 
 resource "aws_db_subnet_group" "database" {
@@ -653,6 +697,12 @@ resource "aws_subnet" "redshift" {
     var.tags,
     var.redshift_subnet_tags,
   )
+  lifecycle {
+  ignore_changes = [
+    tags["Supported_Environment"]
+  ]
+}
+
 }
 
 resource "aws_redshift_subnet_group" "redshift" {
@@ -696,6 +746,12 @@ resource "aws_subnet" "elasticache" {
     var.tags,
     var.elasticache_subnet_tags,
   )
+  lifecycle {
+  ignore_changes = [
+    tags["Supported_Environment"]
+  ]
+}
+
 }
 
 resource "aws_elasticache_subnet_group" "elasticache" {
@@ -739,6 +795,12 @@ resource "aws_subnet" "intra" {
     var.tags,
     var.intra_subnet_tags,
   )
+  lifecycle {
+  ignore_changes = [
+    tags["Supported_Environment"]
+  ]
+}
+
 }
 
 #######################


### PR DESCRIPTION
This change resolves persistent Terraform plan drift caused by conflicting ownership of the Supported_Environment tag on VPC subnets.

The Supported_Environment tag is applied to subnets using aws_ec2_tag resources in this repository. However, the VPC module also manages subnet resources and defines their full tags map.

Because none of the subnet tag merge maps in the VPC module include Supported_Environment, Terraform interprets the tag as undesired on the aws_subnet resources and attempts to remove it (setting it to null) during each plan. This results in repeated in-place updates despite no intentional infrastructure change.

tested locally in the tf-base-vpc repository.
dev:
<img width="1102" height="932" alt="image" src="https://github.com/user-attachments/assets/2f2e3250-cbd5-4a4d-bb41-aae9b20c5969" />
staging:
<img width="1456" height="941" alt="image" src="https://github.com/user-attachments/assets/823b631a-f917-4f4d-8960-7d599c650b5f" />
